### PR TITLE
:sparkles: Feat: Commitar os calendários da página Home separadamente.

### DIFF
--- a/SIME-web-dashboard/src/app/components/calendario-mensal/calendario-mensal.component.css
+++ b/SIME-web-dashboard/src/app/components/calendario-mensal/calendario-mensal.component.css
@@ -1,0 +1,40 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: var(--font-instrument-sans);
+}
+
+p{
+    color: #44A1A0;
+    font-weight: var(--fw-semibold);
+    width: auto;
+    font-size: clamp(18px, 1.5vw, 3.5vw);
+    padding-left: 1.05vw;
+    padding-bottom: 1.5vw;
+}
+
+.calendario-mensal-container {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr); /* 7 colunas para os dias da semana */
+    gap: clamp(4px, 0.2vw, 2.2vw);
+    width: auto;
+    /*width: 20vw;*/
+}
+
+.dia {
+    padding: clamp(4px, 0.6vw, 2.6vw);
+    text-align: center;
+    font-weight: var(--fw-regular);
+    font-size: clamp(15px, 1.2vw, 3.2vw);
+}
+
+.semana {
+    color: #44A1A0;
+    font-weight: var(--fw-semibold);
+}
+
+.dia-mes-anterior {
+  color: #aaa;
+  font-weight: var(--fw-regular);
+}

--- a/SIME-web-dashboard/src/app/components/calendario-mensal/calendario-mensal.component.html
+++ b/SIME-web-dashboard/src/app/components/calendario-mensal/calendario-mensal.component.html
@@ -1,0 +1,22 @@
+<div class="calendario-mensal">   
+    <p>{{ mesAnoAtual }}</p>
+    <div class="calendario-mensal-container">
+      <div class="dia semana">S</div>
+      <div class="dia semana">T</div>
+      <div class="dia semana">Q</div>
+      <div class="dia semana">Q</div>
+      <div class="dia semana">S</div>
+      <div class="dia semana">S</div>
+      <div class="dia semana">D</div>
+
+      <!-- Dias do mês anterior -->
+      <div *ngFor="let dia of ultimosDiasMesAnterior" class="dia dia-mes-anterior">
+        {{ dia }}
+      </div>
+
+      <!-- Dias do mês -->
+      <div *ngFor="let dia of diasDoMes" class="dia">
+        {{ dia }}
+      </div>
+    </div>
+</div> 

--- a/SIME-web-dashboard/src/app/components/calendario-mensal/calendario-mensal.component.spec.ts
+++ b/SIME-web-dashboard/src/app/components/calendario-mensal/calendario-mensal.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CalendarioMensalComponent } from './calendario-mensal.component';
+
+describe('CalendarioMensalComponent', () => {
+  let component: CalendarioMensalComponent;
+  let fixture: ComponentFixture<CalendarioMensalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CalendarioMensalComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CalendarioMensalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/SIME-web-dashboard/src/app/components/calendario-mensal/calendario-mensal.component.ts
+++ b/SIME-web-dashboard/src/app/components/calendario-mensal/calendario-mensal.component.ts
@@ -1,0 +1,48 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-calendario-mensal',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './calendario-mensal.component.html',
+  styleUrls: ['./calendario-mensal.component.css']
+})
+export class CalendarioMensalComponent {
+  mesAnoAtual: string;
+  diasDoMes: number[] = [];
+  ultimosDiasMesAnterior: number[] = [];
+
+  constructor() {
+    const meses = [
+      'Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho',
+      'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro'
+    ];
+
+    const hoje = new Date();
+    const mes = hoje.getMonth();
+    const ano = hoje.getFullYear();
+
+    this.mesAnoAtual = `${meses[mes]} - ${ano}`;
+
+    /* Descobre quantos dias tem o mês atual, pois usamos o Date para o mês seguinte (mes + 1), 
+    mas o 0 verifica o último dia do mês anterior (que seria o mês atual) */
+    const totalDias = new Date(ano, mes + 1, 0).getDate();
+
+    // Dia da semana do primeiro dia do mês (0 = Domingo, 1 = Segunda...)
+    const primeiroDiaSemana = new Date(ano, mes, 1).getDay();
+
+    // Cria array para os dias do mês (1, 2, 3, ..., totalDias)
+    this.diasDoMes = Array.from({ length: totalDias }, (_, i) => i + 1);
+
+    // Para os últimos dias do mês anterior:
+    // Descobre quantos dias tem o mês anterior
+    const totalDiasMesAnterior = new Date(ano, mes, 0).getDate();
+
+    // Pega os últimos 'primeiroDiaSemana' dias do mês anterior para mostrar antes do 1º dia
+    this.ultimosDiasMesAnterior = Array.from(
+      { length: primeiroDiaSemana },
+      (_, i) => totalDiasMesAnterior - primeiroDiaSemana + 1 + i
+    );
+  }
+}

--- a/SIME-web-dashboard/src/app/components/calendario-semanal/calendario-semanal.component.css
+++ b/SIME-web-dashboard/src/app/components/calendario-semanal/calendario-semanal.component.css
@@ -1,0 +1,65 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: var(--font-plus-jakarta-sans);
+}
+
+.calendario-semanal {
+  background-color: #F1EEF6;
+  padding: clamp(10px ,1vw, 3vw);
+  padding-top: clamp(10px, 1.2vw, 3.2vw);
+  border-radius: clamp(5px, 0.6vw, 2.6vw);
+}
+
+p {
+  color: #44A1A0;
+  font-weight: var(--fw-semibold);
+  margin-bottom: clamp(10px, 1vw, 3.2vw);
+  font-size: clamp(15px, 1.2vw, 3.2vw);
+}
+
+.calendario-semanal-container {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  width: auto;
+}
+
+.diasNum {
+  text-align: center;
+  font-size: clamp(15px, 1.25vw, 3.25vw);
+  font-weight: var(--fw-semibold);
+  color: black;
+  height: clamp(30px, 1.7vw, 3.7vw); /* altura igual para todos */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.diasNome {
+  text-align: center;
+  color: #757575;
+  font-weight: var(--fw-medium);
+  font-size: clamp(11.5px, 1vw, 3vw);
+  padding-left: clamp(3px, 0.1vw, 3vw);
+  padding-right: clamp(3px, 0.1vw, 3vw);
+}
+
+.dia-atual {
+  background-color: #44A1A0;
+  color: white;
+}
+
+.dia-atual.semana{
+  font-weight: var(--fw-medium);
+  padding-bottom: clamp(4px, 0.4vw, 2.4vw);
+  border-bottom-left-radius: clamp(5px ,0.5vw, 2.5vw);
+  border-bottom-right-radius: clamp(5px ,0.5vw, 2.5vw);
+}
+
+.dia-atual.num{
+  font-weight: var(--fw-bold);
+  border-top-left-radius: clamp(5px ,0.5vw, 2.5vw);
+  border-top-right-radius: clamp(5px ,0.5vw, 2.5vw);
+  padding: 0 clamp(2px, 0.4vw, 2.4vw); /* só padding horizontal */
+}

--- a/SIME-web-dashboard/src/app/components/calendario-semanal/calendario-semanal.component.html
+++ b/SIME-web-dashboard/src/app/components/calendario-semanal/calendario-semanal.component.html
@@ -1,0 +1,20 @@
+<div class="calendario-semanal">
+    <p>Semana</p>
+    <div class="calendario-semanal-container">
+    
+        <!-- Números -->
+        <div *ngFor="let num of diasNum; let i = index"
+            class="diasNum" 
+            [ngClass]="{ 'dia-atual num': num === diaAtualNum }">
+            {{ num }}
+        </div>
+        
+        <!-- Nomes -->
+        <div *ngFor="let nome of diasDaSemana; let i = index" 
+            class="diasNome" 
+            [ngClass]="{ 'dia-atual semana': i === diaAtualSemana }">
+            {{ nome }}
+        </div>
+        
+    </div>
+</div>

--- a/SIME-web-dashboard/src/app/components/calendario-semanal/calendario-semanal.component.spec.ts
+++ b/SIME-web-dashboard/src/app/components/calendario-semanal/calendario-semanal.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CalendarioSemanalComponent } from './calendario-semanal.component';
+
+describe('CalendarioSemanalComponent', () => {
+  let component: CalendarioSemanalComponent;
+  let fixture: ComponentFixture<CalendarioSemanalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CalendarioSemanalComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CalendarioSemanalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/SIME-web-dashboard/src/app/components/calendario-semanal/calendario-semanal.component.ts
+++ b/SIME-web-dashboard/src/app/components/calendario-semanal/calendario-semanal.component.ts
@@ -1,0 +1,35 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-calendario-semanal',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './calendario-semanal.component.html',
+  styleUrls: ['./calendario-semanal.component.css']
+})
+export class CalendarioSemanalComponent {
+  diasDaSemana = ['dom', 'seg', 'ter', 'qua', 'qui', 'sex', 'sab'];
+  diasNum: number[] = [];
+
+  diaAtualNum!: number;
+  diaAtualSemana!: number;
+
+  constructor() {
+    const hoje = new Date();
+    this.diaAtualNum = hoje.getDate();
+    this.diaAtualSemana = hoje.getDay(); // 0 = Domingo
+
+    // Data do domingo da semana atual
+    const domingo = new Date(hoje);
+    domingo.setDate(hoje.getDate() - this.diaAtualSemana);
+
+    // Criar os 7 dias da semana (número do dia do mês)
+    this.diasNum = Array.from({ length: 7 }, (_, i) => {
+      const data = new Date(domingo);
+      data.setDate(domingo.getDate() + i);
+      return data.getDate();
+    });
+  }
+
+}


### PR DESCRIPTION
- Achei melhor commitar os calendários separadamente em vez de esperar o término da Home, já que o calendário mensal também vai ser usado em outra tela (como na do acompanhamento de chamados).

- Caso alguém teste e a responsividade fique estranha em uma tela diferente da minha, é só avisar. Talvez ele pareça um pouquinho grande nas imagens da Home nos anexos, mas é por conta de ainda não ter os cards dos Ambientes.

<img width="1366" height="638" alt="calendariosSime" src="https://github.com/user-attachments/assets/30631a4d-f49f-4c5e-890f-9690c2232680" />

<img width="898" height="642" alt="calendariosSime2" src="https://github.com/user-attachments/assets/8b32a8f1-7545-4456-831d-2e3ec219cd99" />
